### PR TITLE
Remove `ValueExt::also_mut`

### DIFF
--- a/src/stable/value.rs
+++ b/src/stable/value.rs
@@ -23,31 +23,6 @@ pub trait ValueExt {
         f(self)
     }
 
-    /// Execute function with reference to `self` and return `self`.
-    ///
-    /// # Examples
-    /// ```
-    /// use fntools::value::ValueExt;
-    ///
-    /// let mut also = 0;
-    /// let val = (1 + 3)
-    ///     .also(|it: &i32| assert_eq!(*it, 4))
-    ///     .also(|it| also = it + 1);
-    ///
-    /// assert_eq!(val, 4);
-    /// ```
-    ///
-    /// See also: [`also_mut`](self::ValueExt::also_mut)
-    #[inline]
-    fn also<F>(self, f: F) -> Self
-    where
-        Self: Sized,
-        F: FnOnce(&Self) -> (),
-    {
-        f(&self);
-        self
-    }
-
     /// Execute function with unique reference to `self` and return `self`.
     ///
     /// # Examples
@@ -55,15 +30,13 @@ pub trait ValueExt {
     /// use fntools::value::ValueExt;
     ///
     /// let val = 8
-    ///     .also_mut(|it: &mut i32| assert_eq!(*it, 8))
-    ///     .also_mut(|it| *it *= 2);
+    ///     .also(|it: &mut i32| assert_eq!(*it, 8))
+    ///     .also(|it| *it *= 2);
     ///
     /// assert_eq!(val, 16);
     /// ```
-    ///
-    /// See also: [`also`](self::ValueExt::also)
     #[inline]
-    fn also_mut<F>(mut self, f: F) -> Self
+    fn also<F>(mut self, f: F) -> Self
     where
         Self: Sized,
         F: FnOnce(&mut Self) -> (),


### PR DESCRIPTION
Remove `ValueExt::also_mut` and make `_::also` accept `FnOnce(&mut Self) -> ()` closure.

If we can provide `&mut _` what's the point of providing `&_`?