### PR TITLE
make currying more user friendly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,4 +133,6 @@ pub mod tuple {
     pub mod push;
     /// Take element from tuple (`(T, A, B) => (T, (A, B))`)
     pub mod take;
+
+    pub mod at_least_2;
 }

--- a/src/tuple/at_least_2.rs
+++ b/src/tuple/at_least_2.rs
@@ -1,0 +1,19 @@
+use crate::tuple::take::TupleTake;
+
+/// Tuple with at least 2 elements.
+///
+/// This is a workaround for `Curry` to work
+pub trait AtLeast2
+where
+    // There are at least 2 elements, so we can take 2 elements
+    Self: TupleTake,
+    <Self as TupleTake>::Rem: TupleTake,
+{
+}
+
+impl<T> AtLeast2 for T
+where
+    T: TupleTake,
+    <T as TupleTake>::Rem: TupleTake,
+{
+}

--- a/src/unstable/curry.rs
+++ b/src/unstable/curry.rs
@@ -1,7 +1,8 @@
-use crate::tuple::{push::TuplePush, take::TupleTake};
 use std::marker::PhantomData;
 
-/// **Extremely bad** curring.
+use crate::tuple::{at_least_2::AtLeast2, push::TuplePush, take::TupleTake};
+
+/// Curring.
 ///
 /// ## Examples
 /// ```
@@ -9,29 +10,29 @@ use std::marker::PhantomData;
 /// use std::ops::Add;
 ///
 /// let fun = curry(i32::add);
-/// let res = fun(2)(2)();
-/// //                 ^^ ---- yep, you need this :(
+/// let res = fun(2)(2);
 /// assert_eq!(res, 4);
 /// ```
 #[inline]
-pub fn curry<A, F>(f: F) -> Curry<(), F, A, A>
+pub fn curry<F, Rem>(f: F) -> Curry<(), F, Rem>
 where
-    F: FnOnce<A>,
+    F: FnOnce<Rem>,
 {
     Curry::new(f)
 }
 
-pub struct Curry<T, F, Args, RemArgs> {
-    supplied: T,
+pub struct Curry<Supplied, F, Remaining> {
+    supplied: Supplied,
     f: F,
-    marker: PhantomData<dyn Fn(Args, RemArgs)>,
+    marker: PhantomData<fn(Remaining)>,
 }
 
-impl<F, A> Curry<(), F, A, A> {
+// Nothing is supplied, everything is remaining
+impl<F, Rem> Curry<(), F, Rem> {
     #[inline]
     pub fn new(f: F) -> Self
     where
-        F: FnOnce<A>,
+        F: FnOnce<Rem>,
     {
         Curry {
             supplied: (),
@@ -41,27 +42,37 @@ impl<F, A> Curry<(), F, A, A> {
     }
 }
 
-impl<T, F, A, RA> Curry<T, F, A, RA> {
+impl<S, F, Rem> Curry<S, F, Rem> {
     #[inline]
-    pub fn into_inner(self) -> (T, F) {
+    pub fn into_inner(self) -> (S, F) {
         let Curry { supplied, f, .. } = self;
         (supplied, f)
     }
 
     #[inline]
-    pub fn as_inner(&self) -> (&T, &F) {
+    pub fn as_inner(&self) -> (&S, &F) {
         let Curry { supplied, f, .. } = self;
         (supplied, f)
     }
 }
 
-impl<D, Rem, FArgs, F> FnOnce<(Rem::Take,)> for Curry<D, F, FArgs, Rem>
+impl<S, F, Rem> FnOnce<(Rem::Take,)> for Curry<S, F, Rem>
 where
-    F: FnOnce<FArgs>,
-    Rem: TupleTake,
-    D: TuplePush<Rem::Take>,
+    // This is needed to remove ambiguity with
+    // later "type Output = F::Output;" impls
+    //
+    // The funniest thing about this bound is
+    // that it can't be changed to
+    // Rem: TupleTake,
+    // <Rem as TupleTake>::Rem: TupleTake,
+    // Nevertheless the fact that AtLeast2 is
+    // implemented with blanked impl for all
+    // those types
+    Rem: AtLeast2,
+    Rem::Rem: TupleTake,
+    S: TuplePush<Rem::Take>,
 {
-    type Output = Curry<D::Res, F, FArgs, Rem::Rem>;
+    type Output = Curry<S::Res, F, Rem::Rem>;
 
     #[inline]
     extern "rust-call" fn call_once(self, (arg,): (Rem::Take,)) -> Self::Output {
@@ -74,40 +85,46 @@ where
     }
 }
 
-impl<FArgs, F> FnOnce<()> for Curry<FArgs, F, FArgs, ()>
+impl<S, F, A> FnOnce<(A,)> for Curry<S, F, (A,)>
 where
-    F: FnOnce<FArgs>,
+    S: TuplePush<A>,
+    F: FnOnce<S::Res>,
 {
     type Output = F::Output;
 
     #[inline]
-    extern "rust-call" fn call_once(self, _: ()) -> Self::Output {
+    extern "rust-call" fn call_once(self, (arg,): (A,)) -> Self::Output {
         let Curry { supplied, f, .. } = self;
+        let supplied = supplied.push(arg);
         f.call_once(supplied)
     }
 }
 
-impl<FArgs, F> FnMut<()> for Curry<FArgs, F, FArgs, ()>
+impl<S, F, A> FnMut<(A,)> for Curry<S, F, (A,)>
 where
-    F: FnMut<FArgs>,
-    FArgs: Clone,
+    S: TuplePush<A>,
+    F: FnMut<S::Res>,
+    S: Clone,
 {
     #[inline]
-    extern "rust-call" fn call_mut(&mut self, _: ()) -> Self::Output {
+    extern "rust-call" fn call_mut(&mut self, (arg,): (A,)) -> Self::Output {
         let Curry { supplied, f, .. } = self;
-        f.call_mut(supplied.clone())
+        let supplied = supplied.clone().push(arg);
+        f.call_mut(supplied)
     }
 }
 
-impl<FArgs, F> Fn<()> for Curry<FArgs, F, FArgs, ()>
+impl<S, F, A> Fn<(A,)> for Curry<S, F, (A,)>
 where
-    F: Fn<FArgs>,
-    FArgs: Clone,
+    S: TuplePush<A>,
+    F: Fn<S::Res>,
+    S: Clone,
 {
     #[inline]
-    extern "rust-call" fn call(&self, _: ()) -> Self::Output {
+    extern "rust-call" fn call(&self, (arg,): (A,)) -> Self::Output {
         let Curry { supplied, f, .. } = self;
-        f.call(supplied.clone())
+        let supplied = supplied.clone().push(arg);
+        f.call(supplied)
     }
 }
 
@@ -118,10 +135,9 @@ mod tests {
     #[test]
     fn one_fn() {
         let fun = |a| a * 2;
-        let fun = Curry::new(fun)(4);
+        let val = Curry::new(fun)(4);
 
-        assert_eq!(fun(), 8);
-        assert_eq!(fun(), 8);
+        assert_eq!(val, 8);
     }
 
     #[test]
@@ -133,9 +149,9 @@ mod tests {
             let _ = uncopy;
             a * 2
         };
-        let fun = Curry::new(fun)(4);
+        let val = Curry::new(fun)(4);
 
-        assert_eq!(fun(), 8);
+        assert_eq!(val, 8);
     }
 
     #[test]
@@ -146,19 +162,18 @@ mod tests {
             var = true;
             a * 2
         };
-        let mut fun = Curry::new(fun)(4);
-
         // TODO: for some reason type inheritance doesn't work
-        assert_eq!(fun.call_mut(()), 8);
+        let val = Curry::new(fun).call_mut((4,));
+
+        assert_eq!(val, 8);
     }
 
     #[test]
     fn many_fn() {
         let fun = |a: i32, b: String, c: &str, d: i8| format!("{}{}{}{}", a, b, c, d);
         let fun = Curry::new(fun);
-        let fun = fun(12)(String::from("O_o"))("hell(o)")(4);
+        let val = fun(12)(String::from("O_o"))("hell(o)")(4);
 
-        assert_eq!(fun(), "12O_ohell(o)4");
-        assert_eq!(fun(), "12O_ohell(o)4");
+        assert_eq!(val, "12O_ohell(o)4");
     }
 }

--- a/src/unstable/ext.rs
+++ b/src/unstable/ext.rs
@@ -187,12 +187,11 @@ pub trait FnExt<Args>: Sized {
     /// use std::ops::Add;
     ///
     /// let fun = i32::add.curry();
-    /// let res = fun(2)(2)();
-    /// //                 ^^ ---- yep, you need this, sorry :(
+    /// let res = fun(2)(2);
     /// assert_eq!(res, 4);
     /// ```
     #[inline]
-    fn curry(self) -> Curry<(), Self, Args, Args>
+    fn curry(self) -> Curry<(), Self, Args>
     where
         Self: FnOnce<Args>,
     {


### PR DESCRIPTION
Before this commit, we've been needing to call the curried function without args after
we've "supplied" all the args:
```rust
curry(i32::add)(2)(2)();
// this -------------^^
```

This was needed to remove ambiguity between "supply calls" and "call calls".
But recently I've found another solution - trait that is implemented for tuples
of size 2 or greater - `AtLeast2`. So now there no more redundant call, yay!

Also, this commit removes redundant parameter from `Curry` ty.
Before:
```rust
pub struct Curry<
    T, // Supplied args
    F, // The function
    Args, // Args of the function
    RemArgs, // Remaining args (`Args` without `T`)
> { ... }
```
After:
```rust
pub struct Curry<
    Supplied, // Supplied args
    F, // The function
    Remaining, // Remaining args (`F`'s args without `Supplied`)
> { ... }
```